### PR TITLE
Edge of gameboard now matches the edge of the window

### DIFF
--- a/freegames/snake.py
+++ b/freegames/snake.py
@@ -54,7 +54,7 @@ def move():
     update()
     ontimer(move, 100)
 
-setup(420, 420, 370, 0)
+setup(420, 420, 0, 0)
 hideturtle()
 tracer(False)
 listen()


### PR DESCRIPTION
Fixes a bug where the edge of the window extends beyond the edge of the gameboad.

See the attached screenshot. Notice that the snake has hit the edge of the game board, even though there is another "square" of space between it and the window
<img width="532" alt="Screen Shot 2020-03-30 at 12 10 09 AM" src="https://user-images.githubusercontent.com/56099640/78089623-fec70a80-7395-11ea-8c97-51ec5b418e59.png">
